### PR TITLE
Drop gmp dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,7 +106,6 @@ target_link_libraries(
   PRIVATE
     cpr::cpr
     oxen::logging
-    gmp::gmp
 )
 if(${PROJECT_NAME}_ENABLE_SIGNER)
     target_link_libraries(${PROJECT_NAME} PUBLIC secp256k1)

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ cmake --build build --parallel --verbose
 ```
 # Update pacman and install dependencies
 pacman -Syuu # Terminal may prompt to restart before proceeding
-pacman -S git base-devel libargp-devel cmake gcc libcurl-devel gmp-devel autoconf automake libtool
+pacman -S git base-devel libargp-devel cmake gcc libcurl-devel autoconf automake libtool
 
 # Build
 cmake -B build -S .

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -66,13 +66,3 @@ if(NOT TARGET nlohmann_json::nlohmann_json)
     set(JSON_MultipleHeaders ON CACHE BOOL "") # Allows multi-header nlohmann use
     system_or_submodule(NLOHMANN nlohmann_json nlohmann_json>=3.7.0 json)
 endif()
-
-#
-# GMP
-#
-
-if(NOT TARGET gmp::gmp)
-    pkg_check_modules(GMP gmp IMPORTED_TARGET REQUIRED GLOBAL)
-    add_library(gmp::gmp ALIAS PkgConfig::GMP)
-    message(STATUS "Found gmp ${GMP_VERSION}")
-endif()

--- a/test/src/ethereum_client.cpp
+++ b/test/src/ethereum_client.cpp
@@ -32,7 +32,7 @@ TEST_CASE( "Get balance from sepolia network", "[ethereum]" ) {
     auto balance = signer.provider->getBalance(std::string(ANVIL_ADDRESS));
 
     // Check that the balance is greater than zero
-    REQUIRE( balance != "" );
+    REQUIRE( balance != "0x0" );
 }
 
 TEST_CASE( "HashTest", "[utils]" ) {


### PR DESCRIPTION
The only thing GMP is being used for is a (potential large) hex string -> decimal string conversion, but that can just as easily be left as hex because a large decimal string is really no more useful than a large hex string.  (Also the only code that ever does anything with this just compares it again 0).